### PR TITLE
[Test] Verify that metadata is captured with each slice of large logs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 import Config
 
-config :logger, :default_formatter, metadata: ~w(bar baz foo)a
+config :logger, :default_formatter, metadata: ~w(bar baz foo request_id)a

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 import Config
 
-config :logger, :default_formatter, metadata: ~w(bar baz foo request_id)a
+config :logger, :default_formatter, metadata: ~w(bar baz foo)a

--- a/test/tesla/middleware/meta_logger_test.exs
+++ b/test/tesla/middleware/meta_logger_test.exs
@@ -1,5 +1,5 @@
 defmodule Tesla.Middleware.MetaLoggerTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   require Logger
 

--- a/test/tesla/middleware/meta_logger_test.exs
+++ b/test/tesla/middleware/meta_logger_test.exs
@@ -230,7 +230,7 @@ defmodule Tesla.Middleware.MetaLoggerTest do
     end
 
     test "when the max entry length is given and the logs are split, the metadata is captured with each line" do
-      Logger.metadata(request_id: "123123123")
+      Logger.metadata(foo: "123123123")
 
       body = String.duplicate("x", 100)
 
@@ -242,7 +242,7 @@ defmodule Tesla.Middleware.MetaLoggerTest do
 
       log_lines
       |> Enum.each(fn log_line ->
-        assert log_line =~ "request_id=123123123"
+        assert log_line =~ "foo=123123123"
       end)
     end
 

--- a/test/tesla/middleware/meta_logger_test.exs
+++ b/test/tesla/middleware/meta_logger_test.exs
@@ -229,7 +229,11 @@ defmodule Tesla.Middleware.MetaLoggerTest do
       assert logs =~ "[debug] [#{inspect(Subject)}] #{String.duplicate("b", 100)}\n"
     end
 
-    test "when the max entry length is given and the logs are split, the metadata is captured with each line" do
+    test """
+    For POST requests \
+    when the max entry length is given and the logs are split \
+    the metadata is captured with each line
+    """ do
       Logger.metadata(foo: "123123123")
 
       body = String.duplicate("x", 100)
@@ -237,6 +241,25 @@ defmodule Tesla.Middleware.MetaLoggerTest do
       log_lines =
         capture_log(fn ->
           FakeClient.post("/huge-response", body, opts: [max_entry_length: 10])
+        end)
+        |> String.split("\n\n")
+
+      log_lines
+      |> Enum.each(fn log_line ->
+        assert log_line =~ "foo=123123123"
+      end)
+    end
+
+    test """
+    For GET requests \
+    when the max entry length is given and the logs are split \
+    the metadata is captured with each line
+    """ do
+      Logger.metadata(foo: "123123123")
+
+      log_lines =
+        capture_log(fn ->
+          FakeClient.get("/huge-response", opts: [max_entry_length: 10])
         end)
         |> String.split("\n\n")
 


### PR DESCRIPTION
When the body of a request is larger than the `max_entry_length` we slice the entry and log each portion separately. 
This adds a test to verify that the metadata is logged with each line. 